### PR TITLE
fix: inlude '0' digit in Hex-Regex

### DIFF
--- a/src/main/scala/de/dnpm/dip/service/validation/Validators.scala
+++ b/src/main/scala/de/dnpm/dip/service/validation/Validators.scala
@@ -398,7 +398,7 @@ trait Validators
 
 
 
-  private val hexString64 = "[a-fA-F1-9]{64}".r
+  private val hexString64 = "[a-fA-F0-9]{64}".r
 
   implicit val metadataValidator: Validator[Issue,Submission.Metadata] =
     metadata =>


### PR DESCRIPTION
A hex string could contain the '0' digit.